### PR TITLE
Updating service to Spring Boot 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,10 @@ This project is setup using [Maven](https://maven.apache.org/what-is-maven.html)
 When all the dependencies are downloaded, you can run the project by running the ``main()`` method in the class ``Application`` and then enter [localhost:8080](http://localhost:8080) into the address bar of your favorite web browser.
 
 ## What is going on ?
-Look at the code and find the comments I wrote. I tried explaining what was happening in such a way that it should hopefully be easy to understand.
+Look at the code and find the comments I wrote. I tried explaining what was happening in such a way that it should hopefully be easy to understand. I recommend starting by looking at the [HomeController](https://github.com/danielpall/SpringBootMVC/blob/master/src/main/java/project/controller/HomeController.java#L26).
 
 ### What did you use to make this ?
 I used IntelliJ Ultimate with Maven to setup this project. Students and Teachers get the Ultimate edition for free, apply [here](https://www.jetbrains.com/student/).
-
-### Nothing is working! What can I do ?
-My e-mail is in the course page. Shoot me an e-mail and we'll figure out the problem and solve it.
 
 ### Database
 This project runs an internal database while it is running. If the project is restarted, then all data will be reset, i.e. no data will persist between restarts.

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>HBV501G</groupId>
     <artifactId>Spring_Web_MVC</artifactId>
-    <version>0.1</version>
+    <version>0.2</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.7.RELEASE</version>
+        <version>2.0.3.RELEASE</version>
     </parent>
 
     <dependencies>
@@ -36,6 +36,15 @@
             <artifactId>hsqldb</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!--If you wish to connect this application to a PostgreSQL server then add the dependency below but remove the dependency above (the `hsqldb` one) -->
+        <!--
+        <dependency>
+            <groupId>postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.1-901-1.jdbc4</version>
+        </dependency>
+        -->
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/project/controller/PostitNoteController.java
+++ b/src/main/java/project/controller/PostitNoteController.java
@@ -8,14 +8,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import project.persistence.entities.PostitNote;
-import project.persistence.repositories.PostitNoteRepository;
 import project.service.PostitNoteService;
 
 @Controller
 public class PostitNoteController {
 
     // Instance Variables
-    PostitNoteService postitNoteService;
+    private PostitNoteService postitNoteService;
 
     // Dependency Injection
     @Autowired

--- a/src/main/java/project/persistence/repositories/PostitNoteRepository.java
+++ b/src/main/java/project/persistence/repositories/PostitNoteRepository.java
@@ -33,6 +33,7 @@ public interface PostitNoteRepository extends JpaRepository<PostitNote, Long> {
     //
     List<PostitNote> findAllByOrderByIdDesc();
 
+    @Query(value = "SELECT p FROM PostitNote p WHERE p.id = ?1")
     PostitNote findOne(Long id);
 
     List<PostitNote> findByName(String name);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,11 @@ spring.mvc.view.suffix=.jsp
 # ========================= #
 # DATABASE CONNECTION SETUP #
 # ========================= #
+
+#########################################################################################################
+# NOTICE:                                                                                               #
+# IF YOU USE THESE CONNECTION SETTINGS, YOU MUST ADD THE POSTGRESQL DEPENDENCY IN THE POM.XML DOCUMENT  #
+#########################################################################################################
 # The URL to your database
 #spring.datasource.url=jdbc:postgresql://localhost:5432/HBV
 

--- a/src/main/webapp/WEB-INF/jsp/Index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/Index.jsp
@@ -17,5 +17,5 @@
         <li><a href="/postit">Click here for Persistence Layer Demo</a></li>
     </ul>
     </body>
-    <footer>Class HBV501G, University of Iceland, Fall 2015</footer>
+    <footer>Class HBV501G, University of Iceland</footer>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/postitnotes/PostitNotes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/postitnotes/PostitNotes.jsp
@@ -18,7 +18,7 @@
     <%--Note that the `commandName` given here HAS TO MATCH the name of the attribute--%>
     <%--that is added to the model that is passed to the view.--%>
     <%--See PostitNoteController, method postitNoteViewGet(), and find where this attribute is added to the model.--%>
-    <sf:form method="POST" commandName="postitNote" action="/postit">
+    <sf:form method="POST" modelAttribute="postitNote" action="/postit">
 
         <table>
             <tr>


### PR DESCRIPTION
Fixed things that broke after the major version update, mainly the attribute in .jsp changed from `commandName` to `modelAttribute` and a custom query since the updated JPA package wraps a single return object in `Optional` now.